### PR TITLE
Set of minors pom.xml updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,9 +3,13 @@
 
 	<groupId>org.bonitasoft.web.tooling</groupId>
 	<artifactId>bonita-tomcat-valve</artifactId>
-	<version>7.0.55</version>
+	<version>7.0.67</version>
 	<name>bonita valve</name>
-	
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+	</properties>
+
 	<!--project version is the same as tomcat version to be sure to have a valve corresponding to the right tomcat version -->
 	<dependencies>
 		<dependency>
@@ -15,15 +19,16 @@
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>
-	
+
 	<build>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
+				<version>3.5.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.7</source>
+					<target>1.7</target>
 				</configuration>
 			</plugin>
 		</plugins>


### PR DESCRIPTION
tr(pom.xml): minor changes for coherency and to prevent warning messages

Update Tomcat version from 7.0.55 to 7.0.67 to be coherent with version defined bonita-distrib pom.xml.
Set encoding to UTF-8 to avoid text encoding to be platform dependent in case someone try to compile on Windows.
Define compiler plugin version (3.5.1) so behavior does not change when using a different Maven version.
Set Java version for source and target to 1.7 according to what we officially support.

BREAKING CHANGE: as artifact version as changed bonita-distrib pom.xml will need to be updated. valve.version can be dropped and we can keep only tomcat.version. If such modification is done, deploy/distrib/pom.xml will need to be updated as well.
